### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/Season-2/Level-4/templates/details.html
+++ b/Season-2/Level-4/templates/details.html
@@ -24,7 +24,7 @@
     <br/>
     <p>Search in Google for more information about the planet: <span id="planet"/></p>
     <script>
-        document.getElementById("planet").innerHTML = document.getElementById("name").textContent;
+        document.getElementById("planet").textContent = document.getElementById("name").textContent;
     </script>
 </body>
 


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/skills-secure-code-game/security/code-scanning/19](https://github.com/akabarki76/skills-secure-code-game/security/code-scanning/19)

To fix the issue, we should avoid assigning `textContent` directly to `innerHTML`. Instead, we should use `textContent` for both reading and writing, as it treats the content as plain text and does not interpret it as HTML. This ensures that any special characters in the text are not reinterpreted as HTML, thereby preventing XSS vulnerabilities.

The specific change involves replacing the use of `innerHTML` with `textContent` on line 27. This ensures that the content of the `planet` element is treated as plain text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
